### PR TITLE
Change decorator z-index

### DIFF
--- a/src/modules/view-layer/index.js
+++ b/src/modules/view-layer/index.js
@@ -84,7 +84,7 @@ module.exports = function (_grid) {
         var decoratorContainer = document.createElement('div');
         decoratorContainer.setAttribute('dts', 'grid-decorators');
         util.position(decoratorContainer, 0, 0, 0, 0);
-        decoratorContainer.style.zIndex = '';
+        decoratorContainer.style.zIndex = '3';
         decoratorContainer.style.pointerEvents = 'none';
         return decoratorContainer;
     }


### PR DESCRIPTION
I'm looking to have an element of the grid decorator pop upwards, but I'm having some issues with the z-index as it relates to the header (see images below).  Can you clear up the right way to do this?

**Current Behavior:**
![z_index_issue_1](https://cloud.githubusercontent.com/assets/3506088/15262963/bf195b60-191a-11e6-84ba-b4325dc8884b.png)


**Behavior after changing the z-index of the decorator container:**
![z_index_issue_2](https://cloud.githubusercontent.com/assets/3506088/15262964/bf2c15f2-191a-11e6-9c39-16b035f70253.png)


**Desired behavior:**
![desired_behavior](https://cloud.githubusercontent.com/assets/3506088/15262965/bf321bc8-191a-11e6-9668-4ef9522f0fc3.png)
